### PR TITLE
feat: add issue spotter upload ui

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,685 @@
+// Configuration (adjust to match your backend environment)
+const API_BASE = 'http://localhost:8000';
+const AUTH_TOKEN = 'dev-token'; // developer sets this to match backend
+const POLL_MS_UPLOAD = 1500;
+const POLL_MS_ANALYSIS = 2000;
+const MAX_UPLOAD_MB = 20;
+
+let authToken = AUTH_TOKEN; // session token that can be updated after 401s
+let selectedFile = null;
+let currentUpload = null;
+let currentAnalysisId = null;
+let latestAnalysisResult = null;
+let uploadPollTimer = null;
+let analysisPollTimer = null;
+
+const elements = {
+  dropZone: document.getElementById('dropZone'),
+  fileInput: document.getElementById('fileInput'),
+  fileError: document.getElementById('fileError'),
+  fileDetails: document.getElementById('fileDetails'),
+  fileName: document.getElementById('fileName'),
+  fileSize: document.getElementById('fileSize'),
+  uploadBtn: document.getElementById('uploadBtn'),
+  progressWrapper: document.getElementById('uploadProgress'),
+  progressBar: document.getElementById('progressBar'),
+  uploadInfo: document.getElementById('uploadInfo'),
+  metaFilename: document.getElementById('metaFilename'),
+  metaPages: document.getElementById('metaPages'),
+  metaSize: document.getElementById('metaSize'),
+  metaStatus: document.getElementById('metaStatus'),
+  analyzeBtn: document.getElementById('analyzeBtn'),
+  analysisStatus: document.getElementById('analysisStatus'),
+  systemPrompt: document.getElementById('systemPrompt'),
+  resultsSection: document.getElementById('resultsSection'),
+  documentSummary: document.getElementById('documentSummary'),
+  issuesContainer: document.getElementById('issuesContainer'),
+  copyJsonBtn: document.getElementById('copyJsonBtn'),
+  downloadJsonBtn: document.getElementById('downloadJsonBtn'),
+  actionsRow: document.getElementById('actionsRow'),
+  downloadPdfBtn: document.getElementById('downloadPdfBtn'),
+  deleteBtn: document.getElementById('deleteBtn'),
+  toastContainer: document.getElementById('toastContainer'),
+  maxSizeLabel: document.getElementById('maxSizeLabel'),
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialise);
+} else {
+  initialise();
+}
+
+function initialise() {
+  elements.maxSizeLabel.textContent = `${MAX_UPLOAD_MB} MB`;
+
+  elements.dropZone.addEventListener('click', () => elements.fileInput.click());
+  elements.dropZone.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      elements.fileInput.click();
+    }
+  });
+  elements.dropZone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    elements.dropZone.classList.add('dragover');
+  });
+  elements.dropZone.addEventListener('dragleave', () => {
+    elements.dropZone.classList.remove('dragover');
+  });
+  elements.dropZone.addEventListener('drop', handleFileDrop);
+  elements.fileInput.addEventListener('change', handleFileSelect);
+  elements.uploadBtn.addEventListener('click', () => {
+    if (selectedFile) {
+      uploadSelectedFile();
+    }
+  });
+  elements.analyzeBtn.addEventListener('click', beginAnalysis);
+  elements.copyJsonBtn.addEventListener('click', copyAnalysisJson);
+  elements.downloadJsonBtn.addEventListener('click', downloadAnalysisJson);
+  elements.downloadPdfBtn.addEventListener('click', downloadOriginalPdf);
+  elements.deleteBtn.addEventListener('click', deleteCurrentUpload);
+}
+
+function handleFileDrop(event) {
+  event.preventDefault();
+  elements.dropZone.classList.remove('dragover');
+  const files = event.dataTransfer?.files;
+  if (!files || !files.length) {
+    return;
+  }
+  validateAndSetFile(files[0]);
+}
+
+function handleFileSelect(event) {
+  const files = event.target.files;
+  if (!files || !files.length) {
+    return;
+  }
+  validateAndSetFile(files[0]);
+  event.target.value = '';
+}
+
+function validateAndSetFile(file) {
+  if (!file) {
+    return;
+  }
+  const sizeMb = file.size / (1024 * 1024);
+  const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+
+  if (!isPdf) {
+    showInlineError('Only PDF files are supported.');
+    clearSelectedFile();
+    return;
+  }
+
+  if (sizeMb > MAX_UPLOAD_MB) {
+    showInlineError(`File is too large. Maximum size is ${MAX_UPLOAD_MB} MB.`);
+    clearSelectedFile();
+    return;
+  }
+
+  selectedFile = file;
+  elements.fileName.textContent = file.name;
+  elements.fileSize.textContent = formatBytes(file.size);
+  elements.fileDetails.classList.add('active');
+  elements.uploadBtn.disabled = false;
+  hideInlineError();
+}
+
+function clearSelectedFile() {
+  selectedFile = null;
+  elements.fileName.textContent = 'No file selected';
+  elements.fileSize.textContent = '';
+  elements.fileDetails.classList.remove('active');
+  elements.uploadBtn.disabled = true;
+}
+
+function showInlineError(message) {
+  elements.fileError.textContent = message;
+  elements.fileError.setAttribute('aria-hidden', 'false');
+}
+
+function hideInlineError() {
+  elements.fileError.textContent = '';
+  elements.fileError.setAttribute('aria-hidden', 'true');
+}
+
+function uploadSelectedFile() {
+  if (!selectedFile) {
+    return;
+  }
+
+  clearInterval(uploadPollTimer);
+  clearInterval(analysisPollTimer);
+  analysisPollTimer = null;
+  currentAnalysisId = null;
+  latestAnalysisResult = null;
+
+  elements.uploadBtn.disabled = true;
+  elements.analyzeBtn.disabled = true;
+  elements.analyzeBtn.textContent = 'Run Issue Spotter';
+  elements.progressWrapper.classList.add('active');
+  elements.progressWrapper.setAttribute('aria-hidden', 'false');
+  elements.progressWrapper.setAttribute('aria-valuenow', '0');
+  elements.progressBar.style.width = '0%';
+  elements.resultsSection.hidden = true;
+  elements.resultsSection.classList.remove('active');
+  elements.actionsRow.hidden = true;
+  elements.downloadPdfBtn.disabled = true;
+  elements.deleteBtn.disabled = true;
+  elements.issuesContainer.innerHTML = '';
+  elements.documentSummary.textContent = '—';
+  elements.analysisStatus.textContent = '';
+
+  const formData = new FormData();
+  formData.append('file', selectedFile);
+
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', `${API_BASE}/api/uploads`);
+  xhr.setRequestHeader('Authorization', `Bearer ${authToken}`);
+
+  xhr.upload.onprogress = (event) => {
+    if (!event.lengthComputable) {
+      animateIndeterminateProgress();
+      return;
+    }
+    const percent = Math.round((event.loaded / event.total) * 100);
+    elements.progressBar.style.width = `${percent}%`;
+    elements.progressWrapper.setAttribute('aria-valuenow', String(percent));
+  };
+
+  xhr.onerror = () => {
+    elements.progressWrapper.classList.remove('active');
+    elements.progressWrapper.setAttribute('aria-hidden', 'true');
+    showToast('Upload failed. Please check your connection and try again.', 'error');
+    elements.uploadBtn.disabled = false;
+  };
+
+  xhr.onload = async () => {
+    elements.progressWrapper.classList.remove('active');
+    elements.progressWrapper.setAttribute('aria-hidden', 'true');
+    elements.progressBar.style.width = '0%';
+
+    if (xhr.status === 401) {
+      await handleUnauthorized();
+      elements.uploadBtn.disabled = false;
+      return;
+    }
+
+    if (xhr.status < 200 || xhr.status >= 300) {
+      const message = parseXhrError(xhr) || 'Upload failed.';
+      showToast(message, 'error');
+      elements.uploadBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const response = JSON.parse(xhr.responseText);
+      currentUpload = response;
+      latestAnalysisResult = null;
+      updateUploadMeta({ ...response, filename: response.filename || selectedFile.name, size_bytes: response.size_bytes ?? selectedFile.size });
+      showToast('Upload complete. Extracting document…', 'success');
+      startUploadPolling(response.upload_id);
+      elements.actionsRow.hidden = false;
+      elements.downloadPdfBtn.disabled = false;
+      elements.deleteBtn.disabled = false;
+    } catch (error) {
+      showToast('Unexpected response from server.', 'error');
+      elements.uploadBtn.disabled = false;
+    }
+  };
+
+  xhr.send(formData);
+}
+
+function animateIndeterminateProgress() {
+  elements.progressBar.style.transition = 'none';
+  elements.progressBar.style.width = '30%';
+  requestAnimationFrame(() => {
+    elements.progressBar.style.transition = 'width 0.6s ease';
+    elements.progressBar.style.width = '80%';
+  });
+}
+
+function startUploadPolling(uploadId) {
+  if (!uploadId) return;
+
+  async function poll() {
+    try {
+      const data = await apiFetch(`/api/uploads/${uploadId}/status`);
+      currentUpload = { ...currentUpload, ...data };
+      updateUploadMeta(currentUpload);
+
+      if (data.status === 'ready') {
+        clearInterval(uploadPollTimer);
+        uploadPollTimer = null;
+        elements.analyzeBtn.disabled = false;
+        showToast('Document is ready for analysis.', 'success');
+      } else if (data.status === 'ready_for_analysis') {
+        clearInterval(uploadPollTimer);
+        uploadPollTimer = null;
+        elements.analyzeBtn.disabled = false;
+        updateStatusBadge('ready');
+        showToast('Document is ready for analysis.', 'success');
+      } else if (data.status === 'error') {
+        clearInterval(uploadPollTimer);
+        uploadPollTimer = null;
+        elements.analyzeBtn.disabled = true;
+        showToast('Extraction failed. Please try another document.', 'error');
+      }
+    } catch (error) {
+      showToast(error.message || 'Unable to fetch upload status.', 'error');
+    }
+  }
+
+  poll();
+  uploadPollTimer = setInterval(poll, POLL_MS_UPLOAD);
+}
+
+function updateUploadMeta(upload) {
+  if (!upload) return;
+  elements.uploadInfo.hidden = false;
+  elements.metaFilename.textContent = upload.filename || '—';
+  if (typeof upload.pages === 'number') {
+    elements.metaPages.textContent = String(upload.pages);
+  } else if (upload.page_count) {
+    elements.metaPages.textContent = String(upload.page_count);
+  }
+  if (typeof upload.size_bytes === 'number') {
+    elements.metaSize.textContent = formatBytes(upload.size_bytes);
+  }
+  updateStatusBadge(upload.status || 'uploaded');
+}
+
+function updateStatusBadge(status) {
+  const badge = elements.metaStatus;
+  const readable = formatStatusLabel(status);
+  const normalized = normalizeStatusValue(status);
+  badge.textContent = readable;
+  badge.className = `status-badge${normalized ? ` status-${normalized}` : ''}`;
+}
+
+function formatStatusLabel(status) {
+  if (!status) return '—';
+  const map = {
+    uploaded: 'Uploaded',
+    extracting: 'Extracting',
+    ready: 'Ready',
+    analyzing: 'Analyzing',
+    done: 'Done',
+    error: 'Error',
+    ready_for_analysis: 'Ready',
+    queued: 'Queued',
+    processing: 'Processing',
+    running: 'Running',
+    completed: 'Done',
+  };
+  return map[status.toLowerCase()] || status;
+}
+
+function normalizeStatusValue(status) {
+  if (!status) return '';
+  const value = status.toLowerCase();
+  if (value === 'ready_for_analysis') {
+    return 'ready';
+  }
+  if (value === 'completed') {
+    return 'done';
+  }
+  if (['queued', 'processing', 'running'].includes(value)) {
+    return 'analyzing';
+  }
+  return value;
+}
+
+async function beginAnalysis() {
+  if (!currentUpload?.upload_id) {
+    return;
+  }
+
+  clearInterval(analysisPollTimer);
+  analysisPollTimer = null;
+  latestAnalysisResult = null;
+  elements.resultsSection.hidden = true;
+  elements.analysisStatus.innerHTML = '';
+
+  const promptValue = elements.systemPrompt.value;
+  const payload = {
+    system_prompt: promptValue,
+    prompt: promptValue,
+  };
+
+  try {
+    elements.analyzeBtn.disabled = true;
+    elements.analyzeBtn.textContent = 'Starting…';
+
+    const response = await apiFetch(`/api/analyze/${currentUpload.upload_id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    currentAnalysisId = response.analysis_id;
+    elements.analysisStatus.innerHTML = `<span class="spinner" aria-hidden="true"></span> Analysis queued…`;
+    updateStatusBadge('analyzing');
+    elements.analyzeBtn.textContent = 'Running…';
+    startAnalysisPolling();
+  } catch (error) {
+    elements.analyzeBtn.disabled = false;
+    elements.analyzeBtn.textContent = 'Run Issue Spotter';
+    showToast(error.message || 'Unable to start analysis.', 'error');
+  }
+}
+
+function startAnalysisPolling() {
+  if (!currentAnalysisId) {
+    return;
+  }
+
+  async function poll() {
+    try {
+      const data = await apiFetch(`/api/analyze/${currentAnalysisId}/status`);
+      const { status, progress } = data;
+      updateStatusBadge(status);
+
+      if (status === 'done') {
+        clearInterval(analysisPollTimer);
+        analysisPollTimer = null;
+        elements.analysisStatus.textContent = 'Analysis complete.';
+        elements.analyzeBtn.disabled = false;
+        elements.analyzeBtn.textContent = 'Run Issue Spotter';
+        fetchAnalysisResult();
+      } else if (status === 'error') {
+        clearInterval(analysisPollTimer);
+        analysisPollTimer = null;
+        elements.analysisStatus.textContent = 'Analysis failed.';
+        elements.analyzeBtn.disabled = false;
+        elements.analyzeBtn.textContent = 'Run Issue Spotter';
+        updateStatusBadge('error');
+        showToast('Analysis failed. Please retry.', 'error');
+      } else {
+        let percentText = '';
+        if (typeof progress === 'number' && Number.isFinite(progress)) {
+          const normalized = progress <= 1 ? Math.round(progress * 100) : Math.round(progress);
+          percentText = ` (${normalized}%)`;
+        }
+        elements.analysisStatus.innerHTML = `<span class="spinner" aria-hidden="true"></span> ${formatStatusLabel(status)}${percentText}`;
+      }
+    } catch (error) {
+      showToast(error.message || 'Unable to check analysis status.', 'error');
+    }
+  }
+
+  poll();
+  analysisPollTimer = setInterval(poll, POLL_MS_ANALYSIS);
+}
+
+async function fetchAnalysisResult() {
+  if (!currentAnalysisId) return;
+  try {
+    const result = await apiFetch(`/api/analyze/${currentAnalysisId}/result`);
+    latestAnalysisResult = result;
+    renderResults(result);
+    updateStatusBadge('done');
+    showToast('Results ready.', 'success');
+  } catch (error) {
+    showToast(error.message || 'Could not load analysis result.', 'error');
+  }
+}
+
+function renderResults(result) {
+  if (!result) {
+    return;
+  }
+  elements.resultsSection.hidden = false;
+  elements.resultsSection.classList.add('active');
+  elements.documentSummary.textContent = result.document_summary || 'No summary provided.';
+
+  const issues = Array.isArray(result.issues) ? result.issues : [];
+  elements.issuesContainer.innerHTML = '';
+
+  if (!issues.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No issues were returned by the analysis.';
+    elements.issuesContainer.appendChild(empty);
+  } else {
+    issues.forEach((issue, index) => {
+      elements.issuesContainer.appendChild(createIssueCard(issue, index === 0));
+    });
+  }
+
+  elements.copyJsonBtn.disabled = false;
+  elements.downloadJsonBtn.disabled = false;
+}
+
+function createIssueCard(issue, open = false) {
+  const details = document.createElement('details');
+  details.className = 'issue-card';
+  details.open = open;
+  details.setAttribute('role', 'group');
+
+  const summary = document.createElement('summary');
+  const title = issue.title || 'Untitled issue';
+  const severity = (issue.severity || 'low').toLowerCase();
+  const severityClass = ['high', 'medium', 'low'].includes(severity) ? severity : 'low';
+  const pages = issue.page_range || issue.pages || issue.page || '—';
+
+  const summaryLeft = document.createElement('span');
+  summaryLeft.textContent = title;
+
+  const meta = document.createElement('span');
+  meta.className = 'issue-meta';
+
+  const severityBadge = document.createElement('span');
+  severityBadge.className = `severity severity-${severityClass}`;
+  severityBadge.textContent = severityClass;
+  meta.appendChild(severityBadge);
+
+  const pageLabel = document.createElement('span');
+  pageLabel.textContent = `Pages: ${pages}`;
+  meta.appendChild(pageLabel);
+
+  summary.append(summaryLeft, meta);
+  details.appendChild(summary);
+
+  const body = document.createElement('div');
+  body.className = 'issue-content';
+
+  if (issue.rationale) {
+    const rationale = document.createElement('p');
+    rationale.textContent = issue.rationale;
+    body.appendChild(rationale);
+  }
+
+  const excerpt = document.createElement('pre');
+  excerpt.className = 'issue-excerpt';
+  excerpt.textContent = issue.excerpt || issue.text || 'No excerpt provided.';
+  body.appendChild(excerpt);
+
+  details.appendChild(body);
+  return details;
+}
+
+async function copyAnalysisJson() {
+  if (!latestAnalysisResult) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(latestAnalysisResult, null, 2));
+    showToast('Analysis JSON copied to clipboard.', 'success');
+  } catch (error) {
+    showToast('Unable to copy to clipboard.', 'error');
+  }
+}
+
+function downloadAnalysisJson() {
+  if (!latestAnalysisResult) {
+    return;
+  }
+  const blob = new Blob([JSON.stringify(latestAnalysisResult, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${currentUpload?.filename || 'analysis'}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+async function downloadOriginalPdf() {
+  if (!currentUpload?.upload_id) {
+    return;
+  }
+  try {
+    const blob = await apiFetch(`/api/uploads/${currentUpload.upload_id}/download`);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = currentUpload.filename || 'document.pdf';
+    a.click();
+    URL.revokeObjectURL(url);
+    showToast('Download started.', 'success');
+  } catch (error) {
+    showToast(error.message || 'Unable to download file.', 'error');
+  }
+}
+
+async function deleteCurrentUpload() {
+  if (!currentUpload?.upload_id) {
+    return;
+  }
+  const confirmed = window.confirm('Delete this upload and remove all results?');
+  if (!confirmed) {
+    return;
+  }
+
+  try {
+    await apiFetch(`/api/uploads/${currentUpload.upload_id}`, { method: 'DELETE' });
+    showToast('Upload deleted.', 'success');
+    resetState();
+  } catch (error) {
+    showToast(error.message || 'Unable to delete upload.', 'error');
+  }
+}
+
+function resetState() {
+  clearSelectedFile();
+  elements.uploadInfo.hidden = true;
+  elements.resultsSection.hidden = true;
+  elements.resultsSection.classList.remove('active');
+  elements.actionsRow.hidden = true;
+  elements.downloadPdfBtn.disabled = true;
+  elements.deleteBtn.disabled = true;
+  elements.analysisStatus.textContent = '';
+  elements.documentSummary.textContent = '—';
+  elements.issuesContainer.innerHTML = '';
+  elements.copyJsonBtn.disabled = true;
+  elements.downloadJsonBtn.disabled = true;
+  elements.analyzeBtn.disabled = true;
+  elements.analyzeBtn.textContent = 'Run Issue Spotter';
+  currentUpload = null;
+  currentAnalysisId = null;
+  latestAnalysisResult = null;
+  clearInterval(uploadPollTimer);
+  clearInterval(analysisPollTimer);
+  uploadPollTimer = null;
+  analysisPollTimer = null;
+}
+
+async function apiFetch(path, options = {}) {
+  const { headers = {}, ...rest } = options;
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...rest,
+    headers: {
+      'Authorization': `Bearer ${authToken}`,
+      ...headers,
+    },
+  });
+
+  if (response.status === 401) {
+    await handleUnauthorized();
+    throw new Error('Unauthorized. Update the API token and try again.');
+  }
+
+  if (!response.ok) {
+    let message = `Request failed (${response.status})`;
+    const contentType = response.headers.get('content-type') || '';
+    try {
+      if (contentType.includes('application/json')) {
+        const data = await response.json();
+        message = data?.detail || data?.message || message;
+      } else {
+        const text = await response.text();
+        if (text) {
+          message = text;
+        }
+      }
+    } catch (error) {
+      // Ignore parsing errors and fall back to default message.
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.blob();
+}
+
+async function handleUnauthorized() {
+  showToast('Authentication required. Please provide a valid token.', 'error');
+  const newToken = window.prompt('Enter API token for this session:', authToken || '');
+  if (newToken && newToken.trim()) {
+    authToken = newToken.trim();
+    showToast('Token updated for this session.', 'success');
+  }
+}
+
+function parseXhrError(xhr) {
+  const contentType = xhr.getResponseHeader('content-type') || '';
+  if (contentType.includes('application/json')) {
+    try {
+      const data = JSON.parse(xhr.responseText);
+      return data.detail || data.message;
+    } catch (error) {
+      return null;
+    }
+  }
+  return xhr.responseText;
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) {
+    return '—';
+  }
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const power = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, power);
+  return `${value.toFixed(power === 0 ? 0 : 2)} ${units[power]}`;
+}
+
+function showToast(message, type = 'info') {
+  if (!message) return;
+  const toast = document.createElement('div');
+  toast.className = `toast ${type}`;
+  toast.textContent = message;
+  elements.toastContainer.appendChild(toast);
+  setTimeout(() => {
+    toast.style.opacity = '0';
+    toast.style.transition = 'opacity 0.4s ease';
+    setTimeout(() => {
+      toast.remove();
+    }, 400);
+  }, 3600);
+}
+
+// Disable JSON actions until results exist
+elements.copyJsonBtn.disabled = true;
+elements.downloadJsonBtn.disabled = true;
+elements.downloadPdfBtn.disabled = true;
+elements.deleteBtn.disabled = true;

--- a/index.html
+++ b/index.html
@@ -2,23 +2,31 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>LAWAgent – Legal Intelligence</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <title>Issue Spotter Upload</title>
   <style>
     :root {
-      --bg-gradient: radial-gradient(circle at top left, rgba(15, 170, 255, 0.25), transparent 55%),
-        radial-gradient(circle at bottom right, rgba(0, 255, 170, 0.2), transparent 50%),
-        #05070d;
-      --card-bg: rgba(12, 16, 24, 0.85);
-      --text-primary: #f7f9fc;
-      --text-secondary: #a9b3c7;
-      --accent: linear-gradient(135deg, #05f, #0fa);
-      --accent-strong: linear-gradient(135deg, #00ffd0, #008cff);
-      --border-glow: rgba(15, 170, 255, 0.45);
-      --shadow-elevated: 0 20px 40px rgba(0, 0, 0, 0.45);
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --card-bg: #ffffff;
+      --card-bg-dark: rgba(15, 23, 42, 0.88);
+      --border: rgba(148, 163, 184, 0.35);
+      --border-strong: #2563eb;
+      --accent: #2563eb;
+      --accent-soft: rgba(37, 99, 235, 0.12);
+      --text-primary: #0f172a;
+      --text-secondary: #475569;
+      --text-primary-dark: #f8fafc;
+      --text-secondary-dark: #cbd5f5;
+      --danger: #dc2626;
+      --danger-soft: rgba(220, 38, 38, 0.12);
+      --success: #16a34a;
+      --success-soft: rgba(22, 163, 74, 0.12);
+      --warning: #d97706;
+      --warning-soft: rgba(217, 119, 6, 0.12);
+      --shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+      --radius: 20px;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
 
     * {
@@ -31,280 +39,562 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: var(--bg-gradient);
+      background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.18), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.16), transparent 50%),
+        var(--bg);
+      padding: 32px 16px;
+      font-family: inherit;
+      color: var(--text-primary-dark);
+    }
+
+    .app-card {
+      width: min(920px, 100%);
+      background: rgba(248, 250, 252, 0.92);
       color: var(--text-primary);
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      padding: 48px 24px;
+      padding: clamp(24px, 4vw, 40px);
+      border-radius: var(--radius);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(14px);
+      display: grid;
+      gap: 24px;
     }
 
-    .surface {
-      position: relative;
-      width: min(960px, 100%);
-      padding: 48px clamp(32px, 4vw, 64px);
-      background: var(--card-bg);
-      border: 1px solid rgba(108, 118, 148, 0.2);
-      border-radius: 32px;
-      backdrop-filter: blur(16px);
-      box-shadow: var(--shadow-elevated);
-      overflow: hidden;
-      isolation: isolate;
-    }
-
-    .surface::before,
-    .surface::after {
-      content: "";
-      position: absolute;
-      border-radius: 50%;
-      filter: blur(0);
-      opacity: 0.55;
-      z-index: -1;
-    }
-
-    .surface::before {
-      width: 320px;
-      height: 320px;
-      background: radial-gradient(circle, rgba(0, 153, 255, 0.25), transparent 60%);
-      top: -120px;
-      right: -120px;
-    }
-
-    .surface::after {
-      width: 420px;
-      height: 420px;
-      background: radial-gradient(circle, rgba(0, 255, 170, 0.22), transparent 70%);
-      bottom: -160px;
-      left: -160px;
+    @media (prefers-color-scheme: dark) {
+      .app-card {
+        background: var(--card-bg-dark);
+        color: var(--text-primary-dark);
+      }
     }
 
     header {
       display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-size: 0.75rem;
+      color: rgba(71, 85, 105, 0.8);
+      margin: 0;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .eyebrow {
+        color: rgba(203, 213, 225, 0.75);
+      }
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.6rem, 2.2vw, 2rem);
+    }
+
+    header p {
+      margin: 0;
+      color: var(--text-secondary);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      header p {
+        color: var(--text-secondary-dark);
+      }
+    }
+
+    .drop-zone {
+      border: 2px dashed var(--border);
+      border-radius: var(--radius);
+      padding: 28px;
+      text-align: center;
+      background: rgba(241, 245, 249, 0.6);
+      color: var(--text-secondary);
+      cursor: pointer;
+      position: relative;
+      transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+      outline: none;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .drop-zone {
+        background: rgba(30, 41, 59, 0.6);
+        color: var(--text-secondary-dark);
+      }
+    }
+
+    .drop-zone:focus-visible {
+      border-color: var(--border-strong);
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    .drop-zone.dragover {
+      border-color: var(--border-strong);
+      background: rgba(219, 234, 254, 0.8);
+      transform: scale(1.01);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .drop-zone.dragover {
+        background: rgba(37, 99, 235, 0.2);
+      }
+    }
+
+    .drop-zone strong {
+      color: var(--accent);
+    }
+
+    .drop-zone input[type="file"] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+
+    .inline-error {
+      color: var(--danger);
+      font-size: 0.9rem;
+      margin: 0;
+      display: none;
+    }
+
+    .inline-error[aria-hidden="false"] {
+      display: block;
+    }
+
+    .file-details {
+      display: none;
       align-items: center;
       justify-content: space-between;
-      gap: 16px;
-      margin-bottom: clamp(40px, 6vw, 64px);
+      gap: 12px;
+      flex-wrap: wrap;
+      padding: 16px 18px;
+      border-radius: calc(var(--radius) - 6px);
+      background: rgba(37, 99, 235, 0.08);
+      border: 1px solid rgba(37, 99, 235, 0.16);
     }
 
-    .brand {
+    .file-details.active {
       display: flex;
-      flex-direction: column;
-      align-items: flex-start;
     }
 
-    .brand span {
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      font-weight: 600;
-      color: rgba(167, 177, 200, 0.7);
-      font-size: 0.75rem;
-    }
-
-    h1 {
-      margin: 6px 0 0;
-      font-size: clamp(2.5rem, 5vw, 3.6rem);
-      letter-spacing: -0.03em;
-    }
-
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      padding: 10px 18px;
-      border-radius: 999px;
-      background: rgba(19, 27, 43, 0.8);
-      border: 1px solid rgba(15, 170, 255, 0.3);
-      color: var(--text-secondary);
-      font-size: 0.85rem;
-      font-weight: 500;
-    }
-
-    .hero {
+    .file-info {
       display: grid;
-      gap: clamp(28px, 6vw, 48px);
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      align-items: center;
+      gap: 2px;
     }
 
-    .hero p {
-      font-size: 1.1rem;
-      line-height: 1.7;
-      color: var(--text-secondary);
-      margin: 16px 0 0;
+    .file-info span:first-child {
+      font-weight: 600;
     }
 
-    .cta {
-      margin-top: 32px;
-      display: inline-flex;
-      align-items: center;
-      gap: 14px;
-      padding: 16px 28px;
-      border-radius: 999px;
+    button {
+      font-family: inherit;
       border: none;
-      background-image: var(--accent);
-      color: #010409;
-      font-weight: 600;
-      font-size: 1.05rem;
-      text-decoration: none;
-      transition: transform 0.25s ease, box-shadow 0.25s ease, background-image 0.4s ease;
-      box-shadow: 0 12px 30px rgba(0, 170, 255, 0.25);
-    }
-
-    .cta svg {
-      width: 22px;
-      height: 22px;
-      stroke-width: 2.2;
-    }
-
-    .cta:hover {
-      transform: translateY(-4px) scale(1.01);
-      box-shadow: 0 18px 36px rgba(0, 170, 255, 0.32);
-      background-image: var(--accent-strong);
-    }
-
-    .cta:focus-visible {
-      outline: 3px solid rgba(0, 170, 255, 0.6);
-      outline-offset: 4px;
-    }
-
-    .feature-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 24px;
-      margin-top: clamp(32px, 6vw, 48px);
-    }
-
-    .feature-card {
-      padding: 24px;
-      background: rgba(12, 16, 24, 0.7);
-      border: 1px solid rgba(96, 106, 133, 0.2);
-      border-radius: 20px;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-      transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
-    }
-
-    .feature-card:hover {
-      transform: translateY(-6px);
-      border-color: rgba(15, 170, 255, 0.4);
-      box-shadow: 0 12px 28px rgba(4, 15, 34, 0.45);
-    }
-
-    .feature-icon {
-      width: 46px;
-      height: 46px;
-      border-radius: 14px;
-      display: grid;
-      place-items: center;
-      margin-bottom: 18px;
-      background: rgba(15, 170, 255, 0.14);
-      color: #5cd6ff;
-      font-size: 1.4rem;
-    }
-
-    .feature-card h3 {
-      margin: 0;
-      font-size: 1.25rem;
-      letter-spacing: -0.01em;
-    }
-
-    .feature-card p {
-      margin-top: 12px;
-      margin-bottom: 0;
-      font-size: 0.98rem;
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
-
-    footer {
-      margin-top: clamp(48px, 8vw, 72px);
-      display: flex;
-      flex-direction: column;
+      border-radius: 999px;
+      background: var(--accent);
+      color: white;
+      padding: 10px 20px;
+      font-size: 0.95rem;
+      display: inline-flex;
+      align-items: center;
       gap: 8px;
-      color: rgba(168, 179, 205, 0.6);
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+
+    button:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    button.secondary {
+      background: transparent;
+      color: inherit;
+      border: 1px solid rgba(148, 163, 184, 0.5);
+    }
+
+    button.secondary:hover:not(:disabled) {
+      background: rgba(148, 163, 184, 0.1);
+    }
+
+    button.danger {
+      border-color: rgba(220, 38, 38, 0.5);
+      color: var(--danger);
+    }
+
+    button.danger:hover:not(:disabled) {
+      background: var(--danger-soft);
+    }
+
+    .progress {
+      width: 100%;
+      height: 10px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.25);
+      overflow: hidden;
+      display: none;
+    }
+
+    .progress.active {
+      display: block;
+    }
+
+    .progress-bar {
+      height: 100%;
+      width: 0;
+      background: linear-gradient(90deg, #2563eb, #22d3ee);
+      transition: width 0.2s ease;
+    }
+
+    .upload-meta {
+      display: grid;
+      gap: 8px;
+      padding: 16px;
+      border-radius: calc(var(--radius) - 6px);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      background: rgba(241, 245, 249, 0.55);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .upload-meta {
+        background: rgba(30, 41, 59, 0.65);
+        border-color: rgba(148, 163, 184, 0.25);
+      }
+    }
+
+    .meta-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      background: rgba(148, 163, 184, 0.2);
+      color: var(--text-secondary);
+    }
+
+    .status-uploaded { background: var(--accent-soft); color: var(--accent); }
+    .status-extracting { background: rgba(37, 99, 235, 0.18); color: var(--accent); }
+    .status-ready { background: var(--success-soft); color: var(--success); }
+    .status-analyzing { background: rgba(37, 99, 235, 0.18); color: var(--accent); }
+    .status-done { background: var(--success-soft); color: var(--success); }
+    .status-error { background: var(--danger-soft); color: var(--danger); }
+
+    textarea {
+      width: 100%;
+      min-height: 140px;
+      border-radius: calc(var(--radius) - 8px);
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      padding: 14px;
+      font-size: 1rem;
+      line-height: 1.5;
+      font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: rgba(248, 250, 252, 0.7);
+      resize: vertical;
+    }
+
+    textarea:focus {
+      outline: none;
+      border-color: var(--border-strong);
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      textarea {
+        background: rgba(15, 23, 42, 0.6);
+        color: var(--text-primary-dark);
+      }
+    }
+
+    .analysis-status {
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .analysis-status {
+        color: var(--text-secondary-dark);
+      }
+    }
+
+    .spinner {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      border: 2px solid currentColor;
+      border-top-color: transparent;
+      animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .results {
+      display: none;
+      border-radius: calc(var(--radius) - 6px);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(241, 245, 249, 0.55);
+      padding: 16px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .results {
+        background: rgba(30, 41, 59, 0.65);
+        border-color: rgba(148, 163, 184, 0.25);
+      }
+    }
+
+    .results.active {
+      display: grid;
+      gap: 16px;
+    }
+
+    .summary-box {
+      padding: 12px;
+      border-radius: calc(var(--radius) - 10px);
+      background: rgba(37, 99, 235, 0.08);
+      border: 1px solid rgba(37, 99, 235, 0.16);
+    }
+
+    details.issue-card {
+      border-radius: calc(var(--radius) - 8px);
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      background: rgba(255, 255, 255, 0.85);
+      overflow: hidden;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      details.issue-card {
+        background: rgba(15, 23, 42, 0.7);
+      }
+    }
+
+    details.issue-card + details.issue-card {
+      margin-top: 12px;
+    }
+
+    details.issue-card summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px 16px;
+      font-weight: 600;
+    }
+
+    details.issue-card[open] summary {
+      border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .issue-meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
       font-size: 0.85rem;
     }
 
-    footer span strong {
-      color: rgba(216, 228, 255, 0.7);
+    .severity {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-weight: 600;
+      text-transform: capitalize;
     }
 
-    @media (max-width: 600px) {
-      header {
+    .severity-high { background: var(--danger-soft); color: var(--danger); }
+    .severity-medium { background: var(--warning-soft); color: var(--warning); }
+    .severity-low { background: rgba(148, 163, 184, 0.2); color: var(--text-secondary); }
+
+    .issue-content {
+      padding: 16px;
+      display: grid;
+      gap: 12px;
+      font-size: 0.95rem;
+    }
+
+    .issue-excerpt {
+      background: rgba(15, 23, 42, 0.08);
+      border-radius: 12px;
+      padding: 12px;
+      font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      max-height: 160px;
+      overflow: auto;
+      white-space: pre-wrap;
+    }
+
+    .json-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .actions-row {
+      display: none;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .actions-row.active {
+      display: flex;
+    }
+
+    @media (max-width: 640px) {
+      .file-details,
+      .actions-row,
+      .json-actions {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
       }
 
-      .badge {
-        align-self: flex-start;
-      }
-
-      .cta {
+      .file-details button,
+      .json-actions button,
+      .actions-row button {
         width: 100%;
         justify-content: center;
       }
     }
+
+    .toast-container {
+      position: fixed;
+      right: 16px;
+      bottom: 16px;
+      display: grid;
+      gap: 12px;
+      z-index: 1000;
+    }
+
+    .toast {
+      min-width: 240px;
+      max-width: 320px;
+      padding: 12px 14px;
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.92);
+      color: #f8fafc;
+      box-shadow: var(--shadow);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.9rem;
+      animation: slide-in 0.25s ease;
+    }
+
+    .toast.success { border-left: 3px solid var(--success); }
+    .toast.error { border-left: 3px solid var(--danger); }
+    .toast.info { border-left: 3px solid var(--accent); }
+
+    @keyframes slide-in {
+      from { transform: translateY(12px); opacity: 0; }
+      to { transform: translateY(0); opacity: 1; }
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
   </style>
 </head>
 <body>
-  <main class="surface">
+  <main class="app-card" aria-live="polite">
     <header>
-      <div class="brand">
-        <span>LAWAGENT</span>
-        <h1>Precision legal intelligence on demand</h1>
-      </div>
-      <div class="badge">AI-native workflows for legal teams</div>
+      <p class="eyebrow">LAWAgent Issue Spotter</p>
+      <h1>Upload a filing to surface legal issues</h1>
+      <p>Drop a PDF or choose a file to start extraction. Once the document is ready, run the issue spotter analysis and review actionable findings.</p>
     </header>
 
-    <section class="hero">
+    <section aria-labelledby="uploadLabel">
+      <h2 id="uploadLabel" class="sr-only">Upload document</h2>
+      <div id="dropZone" class="drop-zone" role="button" tabindex="0" aria-describedby="dropHelper">
+        <input id="fileInput" type="file" accept="application/pdf" aria-hidden="true" tabindex="-1">
+        <p id="dropHelper">Drag and drop your PDF here or <strong>browse</strong> to select one.</p>
+        <p>Max size <span id="maxSizeLabel">20 MB</span>.</p>
+      </div>
+      <p id="fileError" class="inline-error" role="alert" aria-hidden="true"></p>
+      <div id="fileDetails" class="file-details" aria-live="polite">
+        <div class="file-info">
+          <span id="fileName">No file selected</span>
+          <span id="fileSize"></span>
+        </div>
+        <button id="uploadBtn" type="button" disabled>Upload PDF</button>
+      </div>
+      <div id="uploadProgress" class="progress" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+        <div id="progressBar" class="progress-bar"></div>
+      </div>
+    </section>
+
+    <section id="uploadInfo" class="upload-meta" aria-live="polite" hidden>
+      <div class="meta-row">
+        <span><strong>File:</strong> <span id="metaFilename">—</span></span>
+        <span><strong>Pages:</strong> <span id="metaPages">—</span></span>
+      </div>
+      <div class="meta-row">
+        <span><strong>Size:</strong> <span id="metaSize">—</span></span>
+        <span><strong>Status:</strong> <span id="metaStatus" class="status-badge">Waiting</span></span>
+      </div>
+    </section>
+
+    <section aria-labelledby="analyzeLabel">
+      <h2 id="analyzeLabel">Issue spotter analysis</h2>
+      <label for="systemPrompt">System prompt</label>
+      <textarea id="systemPrompt">You are a legal issue spotter. Review the uploaded document, identify potential legal issues, classify severity, and provide concise rationale and page references.</textarea>
+      <div class="analysis-status" id="analysisStatus" aria-live="polite"></div>
+      <button id="analyzeBtn" type="button" disabled>Run Issue Spotter</button>
+    </section>
+
+    <section id="resultsSection" class="results" aria-live="polite" hidden>
+      <div class="summary-box">
+        <h3>Document summary</h3>
+        <p id="documentSummary">—</p>
+      </div>
+      <div class="json-actions">
+        <button id="copyJsonBtn" type="button" class="secondary">Copy JSON</button>
+        <button id="downloadJsonBtn" type="button" class="secondary">Download JSON</button>
+      </div>
       <div>
-        <p>
-          LAWAgent streamlines the way legal professionals identify risks, summarize matters, and craft responses.
-          Harness AI that understands legal nuance and delivers actionable insight—securely and instantly.
-        </p>
-        <a class="cta" href="spotter.html">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-          </svg>
-          Launch Issue Spotter
-        </a>
-      </div>
-      <div class="feature-card" style="border-style: dashed; border-color: rgba(92, 214, 255, 0.4); background: rgba(12,16,24,0.55);">
-        <div class="feature-icon" aria-hidden="true">⚖️</div>
-        <h3>Built for modern practices</h3>
-        <p>
-          Upload motions, briefs, or contract excerpts to uncover potential issues in seconds. LAWAgent adapts to your
-          practice area and compliance requirements.
-        </p>
+        <h3>Issues</h3>
+        <div id="issuesContainer"></div>
       </div>
     </section>
 
-    <section class="feature-grid" aria-label="Key capabilities">
-      <article class="feature-card">
-        <div class="feature-icon" aria-hidden="true">🔍</div>
-        <h3>AI Issue Spotting</h3>
-        <p>
-          Surface arguments and red flags before they escalate. Our models are tuned for legal language and citation
-          patterns.
-        </p>
-      </article>
-      <article class="feature-card">
-        <div class="feature-icon" aria-hidden="true">🛡️</div>
-        <h3>Secure by Design</h3>
-        <p>
-          Keep confidential work product safe with privacy-first infrastructure and optional on-prem deployment.
-        </p>
-      </article>
-      <article class="feature-card">
-        <div class="feature-icon" aria-hidden="true">⚡</div>
-        <h3>Workflow Integrations</h3>
-        <p>
-          Connect LAWAgent with your document management and case systems to automate intake, review, and reporting.
-        </p>
-      </article>
+    <section id="actionsRow" class="actions-row" hidden>
+      <button id="downloadPdfBtn" type="button" class="secondary">Download original PDF</button>
+      <button id="deleteBtn" type="button" class="danger secondary">Delete upload</button>
     </section>
-
-    <footer>
-      <span><strong>Need more tools?</strong> Additional AI copilots and research accelerators are coming soon.</span>
-      <span>© <script>document.write(new Date().getFullYear());</script> LAWAgent. All rights reserved.</span>
-    </footer>
   </main>
+
+  <div id="toastContainer" class="toast-container" role="status" aria-live="polite" aria-atomic="true"></div>
+
+  <script type="module" src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build the issue-spotter single page with a responsive upload card, inline validation, and progress feedback
- add centralized API helpers with auth handling plus polling for upload/analysis lifecycle and notifications
- render analysis results with collapsible issue cards, JSON export actions, and document controls

## Testing
- Not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d09c6ff4bc832b9c4099795deccfda